### PR TITLE
Add pluggable AI provider support and task telemetry log

### DIFF
--- a/agents/NOTES.md
+++ b/agents/NOTES.md
@@ -6,15 +6,17 @@
 - Added shared `config/settings.json` to centralize all environment, security, database, and UI settings.
 - Created Windows batch installers/launchers for backend and frontend services.
 - Documented full setup and operations in the root README.
+- Upgraded AI responder with pluggable provider support (template, OpenAI, Ollama) and graceful fallbacks.
+- Introduced persistent task telemetry events with chat annotations, API endpoints, and dashboard timeline.
 
 ## In Progress / Partial
-- AI response generation currently uses an internal stylized template (no external model integration yet).
-- Real task progress auto-increments on chat activity but is not yet connected to real workloads.
+- External AI providers require real credentials and network connectivity to activate (template still the default fallback).
+- Progress events can now be ingested via API, but no automated background job feeds them yet.
 
 ## Next Steps
-- Integrate real AI or LLM backend for dynamic responses.
-- Connect progress metrics to live job metrics or background workers.
+- Ship helper services/agents that push telemetry automatically from long-running tasks.
+- Add analytics around task throughput (per-source counts, average completion time).
 - Harden deployment for production (HTTPS termination, secret rotation, monitoring).
 
 ## Completion Estimate
-Overall solution completion: **68%**
+Overall solution completion: **82%**

--- a/backend/models.py
+++ b/backend/models.py
@@ -44,3 +44,24 @@ class Task(Base):
     progress: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     description: Mapped[str | None] = mapped_column(String(255), nullable=True)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    events: Mapped[list["TaskEvent"]] = relationship(
+        back_populates="task", cascade="all, delete-orphan", lazy="selectin"
+    )
+
+
+class TaskEvent(Base):
+    __tablename__ = "task_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    task_id: Mapped[int] = mapped_column(ForeignKey("tasks.id", ondelete="CASCADE"), nullable=False, index=True)
+    progress: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    source: Mapped[str] = mapped_column(String(120), nullable=False, default="api")
+    note: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, index=True)
+
+    task: Mapped[Task] = relationship(back_populates="events")
+
+    @property
+    def task_name(self) -> str:
+        return self.task.name if self.task else ""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ python-jose==3.3.0
 python-multipart==0.0.9
 pydantic[email]==2.8.2
 alembic==1.13.2
+httpx==0.27.2

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -3,25 +3,29 @@ from __future__ import annotations
 from typing import List
 
 from fastapi import APIRouter, Depends, Query, status
-from sqlalchemy import asc, desc
+from sqlalchemy import desc
 from sqlalchemy.orm import Session
 
 from .. import auth as auth_utils
 from .. import models, schemas
+from ..config import settings
 from ..database import get_db
+from ..services import progress_tracker
 from ..services.responder import generate_ai_response
 
 
-def advance_task_progress(db: Session) -> None:
-    task = (
-        db.query(models.Task)
-        .filter(models.Task.progress < 100)
-        .order_by(asc(models.Task.updated_at))
-        .first()
-    )
-    if task:
-        increment = 7 if task.progress <= 90 else max(1, 100 - task.progress)
-        task.progress = min(100, task.progress + increment)
+def advance_task_progress(db: Session, *, skip_auto: bool) -> None:
+    progress_settings = getattr(settings, "progress_settings", None)
+    auto_increment_enabled = True
+    step = 7
+    if progress_settings is not None:
+        auto_increment_enabled = progress_settings.get("auto_increment_chat", default=True)
+        step = int(progress_settings.get("auto_increment_step", default=7))
+
+    if not auto_increment_enabled or skip_auto:
+        return
+
+    progress_tracker.advance_next_task(db, step=step)
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 
@@ -48,13 +52,32 @@ def post_message(
     current_user: models.User = Depends(auth_utils.get_current_user),
     db: Session = Depends(get_db),
 ) -> List[schemas.MessageResponse]:
-    user_message = models.Message(user_id=current_user.id, role="user", content=message.content.strip())
+    content = message.content.strip()
+    user_message = models.Message(user_id=current_user.id, role="user", content=content)
     ai_content = generate_ai_response(message.content)
     ai_message = models.Message(user_id=current_user.id, role="ai", content=ai_content)
 
     db.add_all([user_message, ai_message])
     db.flush()
-    advance_task_progress(db)
+
+    annotations = progress_tracker.extract_progress_annotations(content)
+    annotation_source = "chat-annotation"
+    progress_settings = getattr(settings, "progress_settings", None)
+    if progress_settings is not None:
+        annotation_source = progress_settings.get("chat_annotation_source", default="chat-annotation")
+
+    for annotation in annotations:
+        task = progress_tracker.get_or_create_task(db, annotation.task_name)
+        note = annotation.note or f"Reported from chat message #{user_message.id}"
+        progress_tracker.apply_progress_event(
+            db,
+            task=task,
+            progress_value=annotation.progress,
+            source=annotation_source,
+            note=note,
+        )
+
+    advance_task_progress(db, skip_auto=bool(annotations))
     db.commit()
     db.refresh(user_message)
     db.refresh(ai_message)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -64,6 +64,31 @@ class TaskResponse(TaskBase):
         from_attributes = True
 
 
+class TaskEventBase(BaseModel):
+    task_name: str = Field(..., min_length=1, max_length=120)
+    progress: int = Field(..., ge=0, le=100)
+    note: Optional[str] = Field(None, max_length=255)
+    source: Optional[str] = Field(None, max_length=120)
+
+
+class TaskEventCreate(TaskEventBase):
+    pass
+
+
+class TaskEventResponse(BaseModel):
+    id: int
+    task_id: int
+    task_name: str
+    progress: int
+    source: str
+    note: Optional[str]
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
 class ProgressReport(BaseModel):
     tasks: List[TaskResponse]
+    events: List[TaskEventResponse]
     overall_progress: float

--- a/backend/services/progress_tracker.py
+++ b/backend/services/progress_tracker.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..config import settings
+
+logger = logging.getLogger(__name__)
+
+_PROGRESS_BLOCK_PATTERN = re.compile(
+    r"\[progress\|(?P<task>[^|\]]+)\|(?P<value>\d{1,3})(?:\|(?P<note>[^\]]+))?\]",
+    flags=re.IGNORECASE,
+)
+
+
+@dataclass(slots=True)
+class ProgressAnnotation:
+    task_name: str
+    progress: int
+    note: str | None = None
+
+
+def _clamp_progress(value: int) -> int:
+    return max(0, min(100, value))
+
+
+def extract_progress_annotations(message: str) -> List[ProgressAnnotation]:
+    annotations: List[ProgressAnnotation] = []
+    for match in _PROGRESS_BLOCK_PATTERN.finditer(message or ""):
+        task_name = match.group("task").strip()
+        if not task_name:
+            continue
+        raw_value = match.group("value")
+        try:
+            progress_value = _clamp_progress(int(raw_value))
+        except ValueError:
+            logger.debug("Unable to parse progress value '%s'", raw_value)
+            continue
+        note = match.group("note")
+        annotations.append(
+            ProgressAnnotation(
+                task_name=task_name,
+                progress=progress_value,
+                note=note.strip() if note else None,
+            )
+        )
+    return annotations
+
+
+def get_or_create_task(db: Session, task_name: str) -> models.Task:
+    task = db.execute(
+        select(models.Task).where(models.Task.name == task_name)
+    ).scalar_one_or_none()
+    if task is None:
+        task = models.Task(name=task_name, progress=0)
+        db.add(task)
+        db.flush()
+    return task
+
+
+def apply_progress_event(
+    db: Session,
+    *,
+    task: models.Task,
+    progress_value: int,
+    source: str,
+    note: str | None = None,
+) -> models.TaskEvent:
+    progress_value = _clamp_progress(progress_value)
+    task.progress = progress_value
+    event = models.TaskEvent(task_id=task.id, progress=progress_value, source=source, note=note)
+    db.add(event)
+    db.flush()
+    return event
+
+
+def advance_next_task(db: Session, step: int) -> models.Task | None:
+    task = db.execute(
+        select(models.Task).where(models.Task.progress < 100).order_by(models.Task.updated_at)
+    ).scalar_one_or_none()
+    if task is None:
+        return None
+    bounded_step = max(1, step)
+    increment = bounded_step if task.progress <= 100 - bounded_step else max(1, 100 - task.progress)
+    task.progress = min(100, task.progress + increment)
+    db.add(task)
+    return task
+
+
+def get_recent_events(db: Session, limit: int) -> List[models.TaskEvent]:
+    return (
+        db.execute(
+            select(models.TaskEvent)
+            .order_by(models.TaskEvent.created_at.desc())
+            .limit(limit)
+        )
+        .scalars()
+        .all()
+    )
+
+
+def calculate_overall_progress(tasks: Iterable[models.Task]) -> float:
+    tasks_list = list(tasks)
+    if not tasks_list:
+        return 0.0
+    total = sum(task.progress for task in tasks_list)
+    return round(total / len(tasks_list), 2)
+
+
+def reset_progress_from_config(db: Session) -> List[models.Task]:
+    db.query(models.TaskEvent).delete()
+    db.query(models.Task).delete()
+
+    seeded_tasks: List[models.Task] = []
+    for entry in getattr(settings, "progress", []):
+        task = models.Task(
+            name=entry["name"],
+            progress=_clamp_progress(int(entry.get("progress", 0))),
+            description=entry.get("description"),
+        )
+        db.add(task)
+        seeded_tasks.append(task)
+    db.flush()
+    return seeded_tasks

--- a/backend/services/responder.py
+++ b/backend/services/responder.py
@@ -1,13 +1,28 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime
+from functools import lru_cache
+from typing import Any, Dict
+
+import httpx
 
 from ..config import settings
 
 
-def generate_ai_response(prompt: str) -> str:
-    """Generate a stylised AI response without external dependencies."""
-    persona = settings.chat.get("ai_persona", default="mystical")
+logger = logging.getLogger(__name__)
+
+
+def _persona_prompt(persona: str) -> str:
+    prompts = {
+        "mystical": "You are Requiem, an ever-watchful AI oracle who speaks in cosmic, ethereal tones while remaining helpful and clear.",
+        "technical": "You are Requiem, a precise senior systems engineer who explains solutions succinctly with technical accuracy.",
+        "mentor": "You are Requiem, a supportive mentor who guides with empathy and actionable advice.",
+    }
+    return prompts.get(persona, prompts["mystical"])
+
+
+def _template_response(prompt: str, persona: str) -> str:
     timestamp = datetime.utcnow().strftime("%H:%M:%S UTC")
     base_response = (
         "I have heard your words and let them echo through the midnight halls. "
@@ -20,3 +35,153 @@ def generate_ai_response(prompt: str) -> str:
     }.get(persona, "Let the nebulae align with your intent.")
 
     return f"[{timestamp}] {base_response}{prompt.strip()} — {closing}"
+
+
+class BaseAIProvider:
+    def generate(self, prompt: str) -> str:  # pragma: no cover - interface definition
+        raise NotImplementedError
+
+
+class TemplateProvider(BaseAIProvider):
+    def __init__(self, persona: str) -> None:
+        self.persona = persona
+
+    def generate(self, prompt: str) -> str:
+        return _template_response(prompt, self.persona)
+
+
+class OpenAIChatProvider(BaseAIProvider):
+    def __init__(self, config: Dict[str, Any], persona: str, timeout: float) -> None:
+        api_key = config.get("api_key")
+        if not api_key or "REPLACE" in api_key:
+            raise ValueError("OpenAI API key is not configured in config/settings.json")
+        self.api_key = api_key
+        self.model = config.get("model", "gpt-4o-mini")
+        self.base_url = config.get("base_url", "https://api.openai.com/v1/chat/completions")
+        self.temperature = float(config.get("temperature", 0.6))
+        self.max_tokens = int(config.get("max_tokens", 256))
+        self.persona = persona
+        self.timeout = timeout
+
+    def generate(self, prompt: str) -> str:
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": _persona_prompt(self.persona)},
+                {"role": "user", "content": prompt.strip()},
+            ],
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.post(self.base_url, headers=headers, json=payload)
+            response.raise_for_status()
+            data = response.json()
+        choices = data.get("choices", [])
+        if not choices:
+            raise ValueError("OpenAI response did not include choices")
+        content = choices[0].get("message", {}).get("content", "")
+        if not content:
+            raise ValueError("OpenAI response did not contain message content")
+        return content.strip()
+
+
+class OllamaChatProvider(BaseAIProvider):
+    def __init__(self, config: Dict[str, Any], persona: str, timeout: float) -> None:
+        base_url = config.get("base_url", "http://localhost:11434")
+        self.model = config.get("model")
+        if not self.model:
+            raise ValueError("Ollama provider requires a model name in config/settings.json")
+        self.url = f"{base_url.rstrip('/')}/api/chat"
+        self.options = config.get("options") or {}
+        self.persona = persona
+        self.timeout = timeout
+
+    def generate(self, prompt: str) -> str:
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": _persona_prompt(self.persona)},
+                {"role": "user", "content": prompt.strip()},
+            ],
+            "stream": False,
+        }
+        if self.options:
+            payload["options"] = self.options
+
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.post(self.url, json=payload)
+            response.raise_for_status()
+            data = response.json()
+
+        message = data.get("message") or {}
+        content = message.get("content")
+        if content:
+            return content.strip()
+
+        choices = data.get("choices", [])
+        if choices:
+            content = choices[0].get("message", {}).get("content")
+            if content:
+                return content.strip()
+
+        raise ValueError("Ollama response did not contain message content")
+
+
+def _chat_settings() -> Any:
+    return getattr(settings, "chat", None)
+
+
+def _timeout_seconds(chat_settings: Any) -> float:
+    if chat_settings is not None:
+        return float(chat_settings.get("request_timeout_seconds", default=30))
+    return 30.0
+
+
+@lru_cache(maxsize=1)
+def _resolved_provider() -> BaseAIProvider:
+    chat_settings = _chat_settings()
+    persona = "mystical"
+    provider_key = "template"
+    providers_config: Dict[str, Any] = {}
+
+    if chat_settings is not None:
+        persona = chat_settings.get("ai_persona", default="mystical")
+        provider_key = chat_settings.get("provider", default="template")
+        providers_config = chat_settings.get("providers", default={}) or {}
+
+    timeout = _timeout_seconds(chat_settings)
+
+    try:
+        if provider_key == "openai":
+            openai_config = providers_config.get("openai", {})
+            return OpenAIChatProvider(openai_config, persona=persona, timeout=timeout)
+        if provider_key == "ollama":
+            ollama_config = providers_config.get("ollama", {})
+            return OllamaChatProvider(ollama_config, persona=persona, timeout=timeout)
+    except Exception as exc:  # noqa: BLE001 - logged and falls back to template provider
+        logger.error("Failed to initialise AI provider '%s': %s", provider_key, exc)
+
+    return TemplateProvider(persona=persona)
+
+
+def generate_ai_response(prompt: str) -> str:
+    provider = _resolved_provider()
+    try:
+        response = provider.generate(prompt)
+        if response:
+            return response
+    except httpx.HTTPError as http_error:
+        logger.error("HTTP error from AI provider: %s", http_error)
+    except Exception as exc:  # noqa: BLE001 - log unexpected provider failures
+        logger.error("AI provider failed, using template response: %s", exc)
+
+    chat_settings = _chat_settings()
+    persona = "mystical"
+    if chat_settings is not None:
+        persona = chat_settings.get("ai_persona", default="mystical")
+    return _template_response(prompt, persona)

--- a/config/settings.json
+++ b/config/settings.json
@@ -25,23 +25,53 @@
   "progress": [
     {
       "name": "Data Parsing",
-      "progress": 85
+      "progress": 85,
+      "description": "Ingesting structured and unstructured payloads."
     },
     {
       "name": "Training Model",
-      "progress": 42
+      "progress": 42,
+      "description": "Executing GPU training cycles against curated corpora."
     },
     {
       "name": "Response Optimization",
-      "progress": 67
+      "progress": 67,
+      "description": "Calibrating inference prompts and latency tolerances."
     },
     {
       "name": "Security Checks",
-      "progress": 100
+      "progress": 100,
+      "description": "Verifying dependency and credential hygiene."
     }
   ],
   "chat": {
-    "ai_persona": "mystical"
+    "ai_persona": "mystical",
+    "provider": "template",
+    "providers": {
+      "openai": {
+        "api_key": "REPLACE_WITH_OPENAI_KEY",
+        "model": "gpt-4o-mini",
+        "base_url": "https://api.openai.com/v1/chat/completions",
+        "temperature": 0.6,
+        "max_tokens": 256
+      },
+      "ollama": {
+        "base_url": "http://localhost:11434",
+        "model": "llama3",
+        "options": {
+          "temperature": 0.6,
+          "num_ctx": 4096
+        }
+      }
+    },
+    "request_timeout_seconds": 30
+  },
+  "progress_settings": {
+    "auto_increment_chat": true,
+    "auto_increment_step": 7,
+    "event_history_limit": 20,
+    "default_event_source": "api",
+    "chat_annotation_source": "chat-annotation"
   },
   "files": {
     "media_root": "media",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ function App() {
   const [user, setUser] = useState(null)
   const [tasks, setTasks] = useState([])
   const [overallProgress, setOverallProgress] = useState(0)
+  const [events, setEvents] = useState([])
   const [messages, setMessages] = useState([])
   const [authLoading, setAuthLoading] = useState(false)
   const [authError, setAuthError] = useState('')
@@ -45,6 +46,7 @@ function App() {
     setUser(null)
     setTasks([])
     setOverallProgress(0)
+    setEvents([])
     setMessages([])
   }
 
@@ -118,6 +120,7 @@ function App() {
     const data = await response.json()
     setTasks(data.tasks ?? [])
     setOverallProgress(Math.round(Number(data.overall_progress ?? 0)))
+    setEvents(data.events ?? [])
   }
 
   const refreshMessages = async () => {
@@ -257,7 +260,7 @@ function App() {
 
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_1fr]">
               <ChatWindow messages={messages} onSend={handleSendMessage} />
-              <ProgressPanel tasks={tasks} overallProgress={overallProgress} />
+              <ProgressPanel tasks={tasks} overallProgress={overallProgress} events={events} />
             </div>
           </div>
         )}

--- a/frontend/src/components/ProgressPanel.jsx
+++ b/frontend/src/components/ProgressPanel.jsx
@@ -1,4 +1,4 @@
-function ProgressPanel({ tasks, overallProgress }) {
+function ProgressPanel({ tasks, overallProgress, events = [] }) {
   return (
     <div className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur">
       <h2 className="text-lg font-semibold uppercase tracking-[0.4em] text-slate-200 mb-4">Code AI Task Progress</h2>
@@ -32,6 +32,33 @@ function ProgressPanel({ tasks, overallProgress }) {
             }`}
             style={{ width: `${overallProgress}%` }}
           />
+        </div>
+      </div>
+      <div className="mt-6">
+        <h3 className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-300 mb-3">Live Task Telemetry</h3>
+        <div className="max-h-48 space-y-3 overflow-y-auto pr-1">
+          {events.length === 0 && (
+            <div className="rounded-xl border border-white/5 bg-midnight/60 px-4 py-3 text-[11px] uppercase tracking-[0.35em] text-slate-400">
+              Awaiting inbound progress signals...
+            </div>
+          )}
+          {events.map((event) => (
+            <div
+              key={event.id}
+              className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-xs shadow-inner"
+            >
+              <div className="flex items-center justify-between font-semibold uppercase tracking-[0.35em] text-slate-200">
+                <span>{event.task_name}</span>
+                <span>{event.progress}%</span>
+              </div>
+              {event.note && (
+                <p className="mt-2 text-[11px] leading-relaxed text-slate-200/80">{event.note}</p>
+              )}
+              <div className="mt-2 text-[10px] uppercase tracking-[0.3em] text-slate-400">
+                {new Date(event.created_at).toLocaleString()} • {event.source}
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- extend the responder service with pluggable providers (template, OpenAI API, and local Ollama) configured through settings.json
- introduce persistent task event tracking with chat annotations, API endpoints, and a frontend telemetry timeline
- document new configuration, API usage, and Windows-friendly progress reporting workflow in the README and agents notes

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8cec883d4832d841e51e09f101714